### PR TITLE
Fix compatibility with Firefox and Safari

### DIFF
--- a/frontend/src/page-cv-editor.html
+++ b/frontend/src/page-cv-editor.html
@@ -37,7 +37,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        on-response="cvSaved"></iron-ajax>
 
     <template is="dom-if" if="[[cvData]]">
-      <cv-editor hidden data='{{cvData}}'></cv-editor>
+      <cv-editor data='{{cvData}}'></cv-editor>
     </template>
 
     <paper-button on-tap="save">Save</paper-button>


### PR DESCRIPTION
This commit closes #9

The cv-editor component had a superfluous "hidden" attribute.

Thanks to @arjun-1 for spotting the attribute on the fly!