### PR TITLE
Make logging more standard

### DIFF
--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -1,42 +1,12 @@
-<!--# galm-log-appender-properties -->
 <configuration>
 
-    <!-- address performance concern with jul-to-slf4j -->
-    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
-        <resetJUL>true</resetJUL>
-    </contextListener>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <property scope="context" name="API_NAME" value="CCO-API" />
-    <property scope="context" name="ENVIRONMENT" value="DOCKER" />
-
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{ISO8601} ${HOSTNAME} ${API_NAME} ${ENVIRONMENT} %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="OPERLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <!--<file>logs/${API_NAME}-monitor.log</file>-->
-        <file>logs/${API_NAME}-monitor.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/${API_NAME}-monitor.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-            <maxHistory>30</maxHistory>
-            <maxFileSize>5MB</maxFileSize>
-            <totalSizeCap>500MB</totalSizeCap>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d{ISO8601} ${HOSTNAME} ${API_NAME} ${ENVIRONMENT} %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <!--<logger name="com.lunatech.cc.api" level="INFO" >-->
-        <!--<appender-ref ref="CONSOLE"/>-->
-        <!--&lt;!&ndash;<appender-ref ref="OPERLOG"/>&ndash;&gt;-->
-    <!--</logger>-->
-
-    <root level="debug">
-        <!--<appender-ref ref="CONSOLE" />-->
-        <appender-ref ref="OPERLOG" />
-    </root>
-
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
 </configuration>

--- a/backend/src/main/scala/com/lunatech/cc/api/CVController.scala
+++ b/backend/src/main/scala/com/lunatech/cc/api/CVController.scala
@@ -85,9 +85,7 @@ class CVController(tokenVerifier: TokenVerifier, cvService: CVService, peopleSer
     for {
       people <- peopleService.findByRole("developer")
       cvs <- Future.value(cvService.findAll.flatMap(_.as[CV].toValidated.toOption))
-      _ = cvs.foreach(println)
     } yield {
-
       people.map { person =>
         Json.obj(
           "person" -> person.asJson,


### PR DESCRIPTION
Gets rid of the generated CCO-xxx-.gz logs that were created. Also removes a println logging in the CV's backend