### PR TITLE
Fix nginx to use polymer for /workshops

### DIFF
--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -21,7 +21,8 @@ http {
 
         location / {
             root   /opt/docker/frontend;
-            index  index.html;
+            index  /index.html;
+            try_files $uri /index.html;
         }
 
         location /api/ {


### PR DESCRIPTION
Now nginx will use index.html/polymer for /workshops and others