### PR TITLE
Replaced video url for Cassandra Core Concepts and Architecture.

### DIFF
--- a/core-curriculum/knowledge/cassandra.json
+++ b/core-curriculum/knowledge/cassandra.json
@@ -104,7 +104,7 @@
         {
           "name": "Core Concepts and architecture",
           "type": "video",
-          "url": "https://academy.datastax.com/resources/ds201-cassandra-core-concepts"
+          "url": "https://academy.datastax.com/resources/ds201-foundations-apache-cassandra"
         }
       ],
       "dependencies": ["apache-cassandra"],


### PR DESCRIPTION
Replaced video url for Cassandra Core Concepts and Architecture. 

Previous url is deprecated (https://academy.datastax.com/resources/ds201-cassandra-core-concepts) and replaced by new url (https://academy.datastax.com/resources/ds201-foundations-apache-cassandra)